### PR TITLE
Use HTTPS submodule URLs for build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "lib/hwsl2_core"]
-	path = lib/hwsl2_core
-	url = git@github.com:MarisaKirisame/hwsl2_core.git
+        path = lib/hwsl2_core
+        url = https://github.com/MarisaKirisame/hwsl2_core.git
 [submodule "lib/monoid_hash"]
-	path = lib/monoid_hash
-	url = git@github.com:waterlens/monoid-hash.git
+        path = lib/monoid_hash
+        url = https://github.com/waterlens/monoid-hash.git
 [submodule "lib/hashtbl"]
-	path = lib/hashtbl
-	url = git@github.com:waterlens/hashtbl.git
+        path = lib/hashtbl
+        url = https://github.com/waterlens/hashtbl.git


### PR DESCRIPTION
## Summary
- switch submodule URLs in `.gitmodules` to HTTPS so dependencies can be fetched without SSH access

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68fdcfc4ed4c8321bd4ec8687d377e82