### PR TITLE
refactor

### DIFF
--- a/lib/SeqOps.ml
+++ b/lib/SeqOps.ml
@@ -1,0 +1,27 @@
+open BatFingerTree
+
+let cons_merge ~monoid ~measure ~merge (et : 'a) (seq : ('a, 'm) Generic.fg) : ('a, 'm) Generic.fg =
+  if Generic.is_empty seq then Generic.singleton et
+  else
+    let tail, head = Generic.front_exn ~monoid ~measure seq in
+    match merge et head with
+    | Some merged -> Generic.cons ~monoid ~measure tail merged
+    | None -> Generic.cons ~monoid ~measure seq et
+
+let snoc_merge ~monoid ~measure ~merge (seq : ('a, 'm) Generic.fg) (et : 'a) : ('a, 'm) Generic.fg =
+  if Generic.is_empty seq then Generic.singleton et
+  else
+    let head, tail = Generic.rear_exn ~monoid ~measure seq in
+    match merge tail et with
+    | Some merged -> Generic.snoc ~monoid ~measure head merged
+    | None -> Generic.snoc ~monoid ~measure seq et
+
+let append_merge ~monoid ~measure ~merge (x : ('a, 'm) Generic.fg) (y : ('a, 'm) Generic.fg) : ('a, 'm) Generic.fg =
+  if Generic.is_empty x then y
+  else if Generic.is_empty y then x
+  else
+    let xh, xt = Generic.rear_exn ~monoid ~measure x in
+    let yt, yh = Generic.front_exn ~monoid ~measure y in
+    match merge xt yh with
+    | Some merged -> Generic.append ~monoid ~measure xh (Generic.cons ~monoid ~measure yt merged)
+    | None -> Generic.append ~monoid ~measure x y

--- a/lib/dune
+++ b/lib/dune
@@ -40,7 +40,8 @@
   CompileType
   CompileSeq
   CompileMemo
-  CompilePlain)
+  CompilePlain
+  SeqOps)
  (preprocess
   (pps ppx_jane ppx_deriving.show ppx_deriving.eq ppx_codegen))
  (foreign_stubs

--- a/lib/runtime/Dependency.ml
+++ b/lib/runtime/Dependency.ml
@@ -13,7 +13,11 @@ type value_subst_cek = value_subst_map cek
 
 let string_of_pattern (p : pattern) : string =
   Generic.to_list p
-  |> List.map (fun pat -> match pat with PVar n -> "H(" ^ string_of_int n ^ ")" | PCon w -> string_of_words w)
+  |> List.map (fun pat ->
+         match pat with
+         | PVar n -> "H(" ^ string_of_int n ^ ")"
+         | Words w -> string_of_words w
+         | Reference r -> string_of_reference r)
   |> String.concat ""
 
 let rec unify (x : pattern) (y : pattern) : pattern =
@@ -39,21 +43,22 @@ let rec unify (x : pattern) (y : pattern) : pattern =
     | _, PVar yh ->
         let xl, xr = pattern_slice x yh in
         return (pattern_append xl (unify xr yt))
-    | PCon xh, PCon yh ->
+    | Words xh, Words yh ->
         let xl = Words.length xh in
         let yl = Words.length yh in
         if xl < yl then
           let yhh, yht = Words.slice_length yh xl in
           (*assert (Words.equal_words xh yhh);*)
-          return (pattern_cons (PCon xh) (unify xt (pattern_cons_unsafe (PCon yht) yt)))
+          return (pattern_cons (Words xh) (unify xt (pattern_cons_unsafe (Words yht) yt)))
         else if xl > yl then
           let xhh, xht = Words.slice_length xh yl in
           (*assert (Words.equal_words xhh yh);*)
-          return (pattern_cons (PCon xhh) (unify (pattern_cons_unsafe (PCon xht) xt) yt))
+          return (pattern_cons (Words xhh) (unify (pattern_cons_unsafe (Words xht) xt) yt))
         else (
           assert (xl = yl);
           (*assert (Words.equal_words xh yh);*)
-          return (pattern_cons (PCon xh) (unify xt yt))))
+          return (pattern_cons (Words xh) (unify xt yt)))
+    | Reference _, _ | _, Reference _ -> failwith "unify: pattern contains Reference")
 
 let rec compose_pattern p s =
   if pattern_is_empty p then match s with [] -> Generic.empty | _ -> failwith "hole count mismatch"
@@ -62,7 +67,8 @@ let rec compose_pattern p s =
     match ph with
     | PVar _ -> (
         match s with sh :: st -> pattern_append sh (compose_pattern pt st) | [] -> failwith "hole count mismatch")
-    | PCon ph -> pattern_cons (PCon ph) (compose_pattern pt s)
+    | Words ph -> pattern_cons (Words ph) (compose_pattern pt s)
+    | Reference _ -> failwith "compose_pattern: pattern contains Reference"
 
 let rec subst_value (s : value_subst_cek) (v : value) : value =
   if Generic.is_empty v then Generic.empty
@@ -73,6 +79,7 @@ let rec subst_value (s : value_subst_cek) (v : value) : value =
         let sm = cek_get s r.src in
         let sub_v = Array.get sm r.hole_idx in
         Value.append (Value.slice sub_v r.offset r.values_count) (subst_value s rest)
+    | rest, PVar _ -> failwith "subst_value: unexpected PVar in value"
 
 let rec value_match_pattern_aux (v : value) (p : pattern) : value list option =
   (*assert (value_valid v);*)
@@ -91,9 +98,9 @@ let rec value_match_pattern_aux (v : value) (p : pattern) : value list option =
         (*assert ((Value.summary vh).degree = (Value.summary vh).max_degree);
         assert ((Value.summary vh).degree = ph);*)
         return (Option.map (fun vs -> vh :: vs) (value_match_pattern_aux vt pt))
-    | PCon ph -> (
-        assert (not (Generic.is_empty ph));
+    | Words ph -> (
         match Value.unwords v ph with None -> return None | Some v -> return (value_match_pattern_aux v pt))
+    | Reference _ -> failwith "value_match_pattern: pattern contains Reference"
 
 let to_value_subst_map (v : value list) : value_subst_map = Array.of_list v
 
@@ -110,7 +117,8 @@ let rec pattern_to_value_aux (p : pattern) src (hole_idx : int ref) : value =
         let r = Reference { src; hole_idx = !hole_idx; offset = 0; values_count = n } in
         hole_idx := !hole_idx + 1;
         Value.value_cons r (pattern_to_value_aux pt src hole_idx)
-    | PCon c -> Value.value_cons (Words c) (pattern_to_value_aux pt src hole_idx)
+    | Words c -> Value.value_cons (Words c) (pattern_to_value_aux pt src hole_idx)
+    | Reference _ -> failwith "pattern_to_value: pattern contains Reference"
 
 let pattern_to_value (p : pattern cek) : value cek = maps_ek (fun p s -> pattern_to_value_aux p s (ref 0)) p
 
@@ -133,7 +141,7 @@ let rec unify_vp_aux (v : value) (p : pattern) (s : pattern_subst_cek) : unit =
         (*assert ((Value.summary vh).degree = (Value.summary vh).max_degree);
         assert ((Value.summary vh).degree = ph);*)
         return (unify_vp_aux vt pt s)
-    | PCon ph -> (
+    | Words ph -> (
         match Generic.front_exn ~monoid:Value.monoid ~measure:Value.measure v with
         | rest, Words w ->
             let pl = Words.length ph in
@@ -144,7 +152,7 @@ let rec unify_vp_aux (v : value) (p : pattern) (s : pattern_subst_cek) : unit =
                 print_endline "should not happens:";
                 print_endline ("phh: " ^ string_of_words phh));
               assert (Lazy.force m.hash = Words.hash phh);
-              return (unify_vp_aux rest (pattern_cons_unsafe (PCon pht) pt) s))
+              return (unify_vp_aux rest (pattern_cons_unsafe (Words pht) pt) s))
             else (
               assert (m.length >= pl);
               match Words.unwords w ph with
@@ -166,7 +174,9 @@ let rec unify_vp_aux (v : value) (p : pattern) (s : pattern_subst_cek) : unit =
               assert (Pattern.pattern_valid ph);
               assert (Pattern.pattern_valid hole_value);*)
             Array.set sm r.hole_idx hole_value;
-            return (unify_vp_aux rest pt s))
+            return (unify_vp_aux rest pt s)
+        | rest, PVar _ -> failwith "unify_vp_aux: unexpected PVar in value")
+    | Reference _ -> failwith "unify_vp_aux: pattern contains Reference"
 
 let unify_vp (v : value cek) (p : pattern cek) (s : pattern_subst_cek) : pattern_subst_cek =
   let _ = zipwith_ek (fun v p -> unify_vp_aux v p s) v p in
@@ -232,7 +242,10 @@ let step_through_with_subst (step : step) (state : state) (subst_val : value Rev
   map_ek (subst_value subst) step.dst
 
 let string_of_pat (p : pat) : string =
-  match p with PVar n -> "PVar(" ^ string_of_int n ^ ")" | PCon w -> "PCon(" ^ string_of_words w ^ ")"
+  match p with
+  | PVar n -> "PVar(" ^ string_of_int n ^ ")"
+  | Words w -> "Words(" ^ string_of_words w ^ ")"
+  | Reference r -> "Reference(" ^ string_of_reference r ^ ")"
 
 let string_of_pattern (p : pattern) : string =
   "[" ^ String.concat ";" (List.map string_of_pat (Generic.to_list p)) ^ "]"
@@ -265,7 +278,10 @@ let compose_step (x : step) (y : step) : step =
       if Generic.is_empty p then []
       else
         let ph, pt = pattern_front_exn p in
-        match ph with PVar n -> Generic.singleton (make_pvar n) :: loop pt | PCon _ -> loop pt
+        match ph with
+        | PVar n -> Generic.singleton (make_pvar n) :: loop pt
+        | Words _ -> loop pt
+        | Reference _ -> failwith "pattern_to_subst_map: pattern contains Reference"
     in
     Array.of_list (loop p)
   in
@@ -312,8 +328,8 @@ let make_step (value : state) (resolved : bool cek) m : step =
               let vht, vhh = Generic.front_exn ~monoid:Words.monoid ~measure:Words.measure vh in
               let vt = if Generic.is_empty vht then vt else Value.value_cons (Words vht) vt in
               Generic.of_list ~monoid:Pattern.monoid ~measure:Pattern.pat_measure
-                (if (Value.summary vt).degree = 0 then [ PCon (Generic.singleton vhh) ]
-                 else [ PCon (Generic.singleton vhh); make_pvar (Value.summary vt).degree ])
+                (if (Value.summary vt).degree = 0 then [ Words (Generic.singleton vhh) ]
+                 else [ Words (Generic.singleton vhh); make_pvar (Value.summary vt).degree ])
           | _ -> failwith "cannot make step"
         else Generic.singleton (make_pvar (Value.summary v).degree))
       value resolved

--- a/lib/runtime/Dependency.ml
+++ b/lib/runtime/Dependency.ml
@@ -14,10 +14,10 @@ type value_subst_cek = value_subst_map cek
 let string_of_pattern (p : pattern) : string =
   Generic.to_list p
   |> List.map (fun pat ->
-         match pat with
-         | PVar n -> "H(" ^ string_of_int n ^ ")"
-         | Words w -> string_of_words w
-         | Reference r -> string_of_reference r)
+      match pat with
+      | PVar n -> "H(" ^ string_of_int n ^ ")"
+      | Words w -> string_of_words w
+      | Reference r -> string_of_reference r)
   |> String.concat ""
 
 let rec unify (x : pattern) (y : pattern) : pattern =

--- a/lib/runtime/Pattern.ml
+++ b/lib/runtime/Pattern.ml
@@ -9,7 +9,6 @@ type measure = Value.measure_t
 
 (*Invariant: consecutive constructors should be fused*)
 type pattern = Value.value
-
 type pat = Value.fg_et = Words of words | Reference of reference | PVar of int
 
 let make_pvar n =

--- a/lib/runtime/Pattern.ml
+++ b/lib/runtime/Pattern.ml
@@ -5,103 +5,30 @@ open BatFingerTree
 (* Design notes on the pattern/value/word relationship now live in
    docs/internal.md#patterns-as-finger-trees-patternml. *)
 (*todo: do we actually need hole_count?*)
-type measure = { degree : int; max_degree : int }
+type measure = Value.measure_t
 
 (*Invariant: consecutive constructors should be fused*)
-type pattern = (pat, measure) Generic.fg
-and pat = PVar of int | PCon of words
+type pattern = Value.value
+
+type pat = Value.fg_et = Words of words | Reference of reference | PVar of int
 
 let make_pvar n =
   assert (n > 0);
   PVar n
 
-let monoid : measure monoid =
-  {
-    zero = { degree = 0; max_degree = 0 };
-    combine = (fun x y -> { degree = x.degree + y.degree; max_degree = max x.max_degree (x.degree + y.max_degree) });
-  }
-
-let pat_measure (p : pat) : measure =
-  match p with
-  | PVar n -> { degree = n; max_degree = n }
-  | PCon c -> { degree = (Words.summary c).degree; max_degree = (Words.summary c).max_degree }
-
-let pattern_measure (p : pattern) : measure = Generic.measure ~monoid ~measure:pat_measure p
+let monoid : measure monoid = Value.monoid
+let pat_measure (p : pat) : measure = Value.measure p
+let pattern_measure (p : pattern) : measure = Value.summary p
 let pattern_is_empty (x : pattern) : bool = Generic.is_empty x
 let pattern_rear_exn (p : pattern) : pattern * pat = Generic.rear_exn ~monoid ~measure:pat_measure p
-
-let pattern_front_exn (p : pattern) : pat * pattern =
-  let rest_p, first_p = Generic.front_exn ~monoid ~measure:pat_measure p in
-  (first_p, rest_p)
-
-let pattern_cons (p : pat) (q : pattern) : pattern =
-  if Generic.is_empty q then Generic.singleton p
-  else
-    let qh, qt = pattern_front_exn q in
-    match (p, qh) with
-    | PVar p, PVar qh -> Generic.cons ~monoid ~measure:pat_measure qt (make_pvar (p + qh))
-    | PCon p, PCon qh -> Generic.cons ~monoid ~measure:pat_measure qt (PCon (Words.append p qh))
-    | PCon _, PVar _ | PVar _, PCon _ -> Generic.cons ~monoid ~measure:pat_measure q p
-
-let pattern_snoc (p : pattern) (q : pat) : pattern =
-  if Generic.is_empty p then Generic.singleton q
-  else
-    let ph, pt = pattern_rear_exn p in
-    match (pt, q) with
-    | PVar pt, PVar q -> Generic.snoc ~monoid ~measure:pat_measure ph (make_pvar (pt + q))
-    | PCon pt, PCon q -> Generic.snoc ~monoid ~measure:pat_measure ph (PCon (Words.append pt q))
-    | PCon _, PVar _ | PVar _, PCon _ -> Generic.snoc ~monoid ~measure:pat_measure p q
-
+let pattern_front_exn (p : pattern) : pat * pattern = Value.front_exn p
+let pattern_cons (p : pat) (q : pattern) : pattern = Value.value_cons p q
+let pattern_snoc (p : pattern) (q : pat) : pattern = Value.value_snoc p q
 let pattern_append_unsafe x y = Generic.append ~monoid ~measure:pat_measure x y
-let pattern_cons_unsafe x y = Generic.cons ~monoid ~measure:pat_measure y x
-let pattern_snoc_unsafe x y = Generic.snoc ~monoid ~measure:pat_measure x y
-
-let rec pattern_append (x : pattern) (y : pattern) : pattern =
-  if Generic.is_empty x then y
-  else if Generic.is_empty y then x
-  else
-    let rest_x, last_x = pattern_rear_exn x in
-    let first_y, rest_y = pattern_front_exn y in
-    let with_middle middle = pattern_append_unsafe rest_x (pattern_cons_unsafe middle rest_y) in
-    match (last_x, first_y) with
-    | PVar n1, PVar n2 -> with_middle (make_pvar (n1 + n2))
-    | PCon c1, PCon c2 -> with_middle (PCon (Words.append c1 c2))
-    | _ -> pattern_append_unsafe x y
-
-let pattern_slice (p : pattern) (offset : int) : pattern * pattern =
-  assert (offset >= 0);
-  let return x y =
-    (*assert ((pattern_measure x).degree = (pattern_measure x).max_degree);
-    assert ((pattern_measure x).degree = offset);
-    assert (offset + (pattern_measure y).degree = (pattern_measure p).degree);*)
-    (x, y)
-  in
-  if offset = 0 then return Generic.empty p
-  else
-    let x, y = Generic.split ~monoid ~measure:pat_measure (fun m -> not (m.max_degree < offset)) p in
-    (*assert ((pattern_measure x).max_degree < offset);*)
-    let d = (pattern_measure x).degree in
-    assert (d < offset);
-    let needed = offset - d in
-    assert (needed > 0);
-    let yh, yt = pattern_front_exn y in
-    match yh with
-    | PVar n ->
-        assert (d + n >= offset);
-        assert (needed <= n);
-        let left = pattern_snoc_unsafe x (make_pvar needed) in
-        let right = if n - needed > 0 then pattern_cons_unsafe (make_pvar (n - needed)) yt else yt in
-        return left right
-    | PCon c ->
-        let cd = (Words.summary c).max_degree in
-        assert (d + cd >= offset);
-        assert (needed <= cd);
-        let c_words, c_children = Words.slice_degree c needed in
-        (*assert ((Words.summary c_words).degree = needed);
-        assert ((Words.summary c_words).max_degree = needed);*)
-        let left = pattern_snoc_unsafe x (PCon c_words) in
-        let right = if not (Generic.is_empty c_children) then pattern_cons_unsafe (PCon c_children) yt else yt in
-        return left right
+let pattern_cons_unsafe x y = Value.value_cons_unsafe x y
+let pattern_snoc_unsafe x y = Value.value_snoc_unsafe x y
+let pattern_append (x : pattern) (y : pattern) : pattern = Value.append x y
+let pattern_slice (p : pattern) (offset : int) : pattern * pattern = Value.pop_n p offset
 
 (*todo: rename all pop_n to drop_n*)
 let pattern_pop_n (p : pattern) (n : int) : pattern =
@@ -114,12 +41,13 @@ let pattern_pop_n (p : pattern) (n : int) : pattern =
   | Some (rest, y) -> (
       match Generic.front rest ~monoid ~measure:pat_measure with
       | None -> true
-      | Some (_, z) ->
-          (match (y, z) with
-            | PCon _, PCon _ -> false
-            | PCon _, _ -> true
-            | PVar _, PVar _ -> false
-            | PVar _, _ -> true)
+      | Some (_, z) -> (
+          match (y, z) with
+          | Words _, Words _ -> false
+          | Words _, _ -> true
+          | PVar _, PVar _ -> false
+          | PVar _, _ -> true
+          | Reference _, _ -> true)
           && pattern_valid rest)*)
 
 let rec pattern_pvar_count x : int =

--- a/lib/runtime/Value.ml
+++ b/lib/runtime/Value.ml
@@ -2,6 +2,7 @@ open BatFingerTree
 module Hasher = Hash.MCRC32C
 open Word
 include Reference
+open SeqOps
 
 (* Values extend the word finger tree with References so we can represent
  * partially materialised environments/continuations.
@@ -50,30 +51,13 @@ let summary x = Generic.measure ~monoid ~measure x
 let value_measure x = summary x
 
 let append (x : seq) (y : seq) : seq =
-  if Generic.is_empty x then y
-  else if Generic.is_empty y then x
-  else
-    let xh, xt = Generic.rear_exn ~monoid ~measure x in
-    let yt, yh = Generic.front_exn ~monoid ~measure y in
-    match merge_fg_et xt yh with
-    | Some merged -> Generic.append ~monoid ~measure xh (Generic.cons ~monoid ~measure yt merged)
-    | None -> Generic.append ~monoid ~measure x y
+  append_merge ~monoid ~measure ~merge:merge_fg_et x y
 
 let value_cons (et : fg_et) (v : seq) : seq =
-  if Generic.is_empty v then Generic.singleton et
-  else
-    let vt, vh = Generic.front_exn ~monoid ~measure v in
-    match merge_fg_et et vh with
-    | Some merged -> Generic.cons ~monoid ~measure vt merged
-    | None -> Generic.cons ~monoid ~measure v et
+  cons_merge ~monoid ~measure ~merge:merge_fg_et et v
 
 let value_snoc (v : seq) (et : fg_et) : seq =
-  if Generic.is_empty v then Generic.singleton et
-  else
-    let vh, vt = Generic.rear_exn ~monoid ~measure v in
-    match merge_fg_et vt et with
-    | Some merged -> Generic.snoc ~monoid ~measure vh merged
-    | None -> Generic.snoc ~monoid ~measure v et
+  snoc_merge ~monoid ~measure ~merge:merge_fg_et v et
 
 let value_snoc_unsafe (v : seq) (et : fg_et) : seq = Generic.snoc ~monoid ~measure v et
 let value_cons_unsafe (et : fg_et) (v : seq) : seq = Generic.cons ~monoid ~measure v et

--- a/lib/runtime/Value.ml
+++ b/lib/runtime/Value.ml
@@ -6,7 +6,7 @@ include Reference
 (* Values extend the word finger tree with References so we can represent
  * partially materialised environments/continuations.
  *)
-type fg_et = Words of Words.words | Reference of reference [@@deriving eq]
+type fg_et = Words of Words.words | Reference of reference | PVar of int [@@deriving eq]
 
 type value = (fg_et, measure_t) Generic.fg
 and seq = value
@@ -25,6 +25,13 @@ let measure (et : fg_et) : measure_t =
       let m = Words.summary w in
       { degree = m.degree; max_degree = m.max_degree }
   | Reference r -> { degree = r.values_count; max_degree = r.values_count }
+  | PVar n -> { degree = n; max_degree = n }
+
+let merge_fg_et (x : fg_et) (y : fg_et) : fg_et option =
+  match (x, y) with
+  | PVar x, PVar y -> Some (PVar (x + y))
+  | Words x, Words y -> Some (Words (Words.append x y))
+  | _ -> None
 
 let rec value_valid x : bool =
   match Generic.front x ~monoid ~measure with
@@ -34,10 +41,9 @@ let rec value_valid x : bool =
       | None -> true
       | Some (_, y) ->
           (match (x, y) with
-            | Reference _, Reference _ -> true
-            | Reference _, Words _ -> true
             | Words _, Words _ -> false
-            | Words _, Reference _ -> true)
+            | PVar _, PVar _ -> false
+            | _ -> true)
           && value_valid rest)
 
 let summary x = Generic.measure ~monoid ~measure x
@@ -49,26 +55,25 @@ let append (x : seq) (y : seq) : seq =
   else
     let xh, xt = Generic.rear_exn ~monoid ~measure x in
     let yt, yh = Generic.front_exn ~monoid ~measure y in
-    match (xt, yh) with
-    | Words xt, Words yh ->
-        Generic.append ~monoid ~measure xh (Generic.cons ~monoid ~measure yt (Words (Words.append xt yh)))
-    | _ -> Generic.append ~monoid ~measure x y
+    match merge_fg_et xt yh with
+    | Some merged -> Generic.append ~monoid ~measure xh (Generic.cons ~monoid ~measure yt merged)
+    | None -> Generic.append ~monoid ~measure x y
 
 let value_cons (et : fg_et) (v : seq) : seq =
   if Generic.is_empty v then Generic.singleton et
   else
     let vt, vh = Generic.front_exn ~monoid ~measure v in
-    match (et, vh) with
-    | Words et, Words vh -> Generic.cons ~monoid ~measure vt (Words (Words.append et vh))
-    | _ -> Generic.cons ~monoid ~measure v et
+    match merge_fg_et et vh with
+    | Some merged -> Generic.cons ~monoid ~measure vt merged
+    | None -> Generic.cons ~monoid ~measure v et
 
 let value_snoc (v : seq) (et : fg_et) : seq =
   if Generic.is_empty v then Generic.singleton et
   else
     let vh, vt = Generic.rear_exn ~monoid ~measure v in
-    match (vt, et) with
-    | Words vt, Words et -> Generic.snoc ~monoid ~measure vh (Words (Words.append vt et))
-    | _ -> Generic.snoc ~monoid ~measure v et
+    match merge_fg_et vt et with
+    | Some merged -> Generic.snoc ~monoid ~measure vh merged
+    | None -> Generic.snoc ~monoid ~measure v et
 
 let value_snoc_unsafe (v : seq) (et : fg_et) : seq = Generic.snoc ~monoid ~measure v et
 let value_cons_unsafe (et : fg_et) (v : seq) : seq = Generic.cons ~monoid ~measure v et
@@ -99,6 +104,15 @@ let rec pop_n (s : seq) (n : int) : seq * seq =
         let l = value_snoc_unsafe x (Words vh) in
         let r = if Words.is_empty vt then w else value_cons_unsafe (Words vt) w in
         (l, r)
+    | PVar v ->
+        assert (m.degree < n);
+        assert (m.degree + v >= n);
+        let need = n - m.degree in
+        let l = value_snoc_unsafe x (PVar need) in
+        if v = need then (l, w)
+        else
+          let r = value_cons_unsafe (PVar (v - need)) w in
+          (l, r)
     | Reference v ->
         assert (m.degree < n);
         assert (m.degree + v.values_count >= n);
@@ -133,7 +147,10 @@ let string_of_reference (r : reference) : string =
   str
 
 let string_of_fg_et (et : fg_et) : string =
-  match et with Words w -> Words.string_of_words w | Reference r -> string_of_reference r
+  match et with
+  | Words w -> Words.string_of_words w
+  | Reference r -> string_of_reference r
+  | PVar n -> "H(" ^ string_of_int n ^ ")"
 
 let rec string_of_value_aux (v : value) : string =
   if Generic.is_empty v then ""
@@ -155,11 +172,4 @@ let unwords (v : value) (w : Words.words) : value option =
           (*assert (value_valid ret);*)
           Some ret
       | None -> None)
-  | Reference _ -> None
-
-let value_to_words (v : value) : Words.words =
-  let vt, vh = Generic.front_exn ~measure ~monoid v in
-  assert (Generic.is_empty vt);
-  match vh with
-  | Words vh_words -> vh_words
-  | Reference r -> failwith ("value_to_words: expected Words but found Reference " ^ string_of_reference r)
+  | Reference _ | PVar _ -> None

--- a/lib/runtime/Value.ml
+++ b/lib/runtime/Value.ml
@@ -41,24 +41,13 @@ let rec value_valid x : bool =
       match Generic.front rest ~monoid ~measure with
       | None -> true
       | Some (_, y) ->
-          (match (x, y) with
-            | Words _, Words _ -> false
-            | PVar _, PVar _ -> false
-            | _ -> true)
-          && value_valid rest)
+          (match (x, y) with Words _, Words _ -> false | PVar _, PVar _ -> false | _ -> true) && value_valid rest)
 
 let summary x = Generic.measure ~monoid ~measure x
 let value_measure x = summary x
-
-let append (x : seq) (y : seq) : seq =
-  append_merge ~monoid ~measure ~merge:merge_fg_et x y
-
-let value_cons (et : fg_et) (v : seq) : seq =
-  cons_merge ~monoid ~measure ~merge:merge_fg_et et v
-
-let value_snoc (v : seq) (et : fg_et) : seq =
-  snoc_merge ~monoid ~measure ~merge:merge_fg_et v et
-
+let append (x : seq) (y : seq) : seq = append_merge ~monoid ~measure ~merge:merge_fg_et x y
+let value_cons (et : fg_et) (v : seq) : seq = cons_merge ~monoid ~measure ~merge:merge_fg_et et v
+let value_snoc (v : seq) (et : fg_et) : seq = snoc_merge ~monoid ~measure ~merge:merge_fg_et v et
 let value_snoc_unsafe (v : seq) (et : fg_et) : seq = Generic.snoc ~monoid ~measure v et
 let value_cons_unsafe (et : fg_et) (v : seq) : seq = Generic.cons ~monoid ~measure v et
 

--- a/nightly.py
+++ b/nightly.py
@@ -39,7 +39,8 @@ def _resolve_switch() -> str:
 
 
 SWITCH = _resolve_switch()
-TOOLCHAIN_PACKAGES = [
+PACKAGES = [
+    "core",
     "dune",
 ]
 DEV_PACKAGES = [


### PR DESCRIPTION
Unified pattern/value into a shared sequence element type by extending `Value.fg_et` with `PVar`, then moved pattern ops onto the Value implementation and updated dependency/memo/read logic to use the common constructors and guard against illegal cross‑use.

This keeps a single underlying type while preserving existing call sites.
