### PR TITLE
Use tag type to denote compiler modules in Cmdliner.

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,6 +1,19 @@
 open Cmdliner
 open Ant
 
+(* A simple tag denotes the real backend,
+   which can be used by Cmdliner to do equality comparison. *)
+type backend_tag = PlainBackend | SeqBackend | MemoBackend
+
+let compile_with_backend backend frontend =
+  let module M =
+    (val match backend with
+         | PlainBackend -> (module CompilePlain.Backend : Compile.Backend)
+         | SeqBackend -> (module CompileSeq.Backend : Compile.Backend)
+         | MemoBackend -> (module CompileMemo.Backend : Compile.Backend))
+  in
+  M.compile frontend
+
 let read_all file = In_channel.with_open_text file In_channel.input_all
 
 let parse content =
@@ -20,8 +33,7 @@ let parse content =
       Printf.eprintf "Lexing error at line %d, character %d: %s\n" line cnum @@ Lexer.string_of_error e;
       failwith "Failed due to lexing error"
 
-let driver input output print_ast compile_pat compile_ant type_alias (module Backend : Compile.Backend) typing
-    print_level print_anf =
+let driver input output print_ast compile_pat compile_ant type_alias backend_tag typing print_level print_anf =
   let src = read_all input in
   let syn = parse src in
   let ast = Typing.top_type_of_prog syn in
@@ -37,7 +49,7 @@ let driver input output print_ast compile_pat compile_ant type_alias (module Bac
     if debug then debug_pp (Syntax.pp_prog ast);
     if print_ast then output_pp (Syntax.pp_prog ast);
     if compile_pat then output_pp (Pat.show_all_pattern_matrixes frontend);
-    if compile_ant then output_pp (Backend.compile frontend);
+    if compile_ant then output_pp (compile_with_backend backend_tag frontend);
     if typing then output_pp (Typing.pp_top_type_of_prog ~print_level ast);
     if print_anf then output_pp (Syntax.pp_prog (Transform.anf_prog ast))
   in
@@ -59,14 +71,8 @@ let print_ast =
 
 let backend =
   let doc = "Backend used to compile the ant source, defaulting to memo" in
-  let cdds =
-    [
-      ("memo", (module CompileMemo.Backend : Compile.Backend));
-      ("seq", (module CompileSeq.Backend : Compile.Backend));
-      ("plain", (module CompilePlain.Backend : Compile.Backend));
-    ]
-  in
-  Arg.(value & opt (enum cdds) (module CompileMemo.Backend : Compile.Backend) & info [ "b"; "backend" ] ~doc)
+  let cdds = [ ("memo", MemoBackend); ("seq", SeqBackend); ("plain", PlainBackend) ] in
+  Arg.(value & opt (enum cdds) MemoBackend & info [ "b"; "backend" ] ~doc)
 
 let compile_ant =
   let doc = "Compile the ant source" in

--- a/dune.lock/dune-configurator.3.23.1.pkg
+++ b/dune.lock/dune-configurator.3.23.1.pkg
@@ -1,4 +1,4 @@
-(version 3.23.0)
+(version 3.23.1)
 
 (build
  (all_platforms
@@ -14,6 +14,6 @@
 (source
  (fetch
   (url
-   https://github.com/ocaml/dune/releases/download/3.23.0/dune-3.23.0.tbz)
+   https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz)
   (checksum
-   sha512=ef42c7ac24f300c00c429ea0e7e152bb46f7bbb1e81cf1dad225c4f41598f744b83d404a8ac949c2da074288f5560c8770421ba474a5751a20090b2f9cfa2435)))
+   sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd)))

--- a/dune.lock/lock.dune
+++ b/dune.lock/lock.dune
@@ -10,7 +10,7 @@
   ((source
     https://github.com/ocaml-dune/opam-overlays.git#2a9543286ff0e0656058fee5c0da7abc16b8717d))
   ((source
-    https://github.com/ocaml/opam-repository.git#28d044eb9ccd9b9275c54a845b30932c3d934aa0))))
+    https://github.com/ocaml/opam-repository.git#8acb7748e10a3e244469bbfef24f2d61f0ff9a7f))))
 
 (expanded_solver_variable_bindings
  (variable_values


### PR DESCRIPTION
Fixes https://github.com/MarisaKirisame/ant/issues/61

Cmdliner use List.assoc to find the description of an option value to generate help document, which relies on the structural equality of OCaml. However, such equality is not defined on first-class module. Therefore, invoking "ant --help" will raise Invalid_argument exception.

This commit solve the problem by using a simple tag type (which is structural comparable) to denote the real compiler modules in the entry of ant.

* bin/main.ml (backend_tag): New type definition. (compile_with_backend): New function to call backend compiler on tags. (driver): Replace 'Backend' argument with 'backend_tag', Replace 'Backend.compile' with 'compile_with_backend'.
(backend): Replace modules with their corresponding tags.